### PR TITLE
Exporting types

### DIFF
--- a/src/CosmosQueryBuilder.ts
+++ b/src/CosmosQueryBuilder.ts
@@ -4,7 +4,7 @@ import type { ArrayElement, Path, PathValue, PickPath, UnionToIntersection } fro
 
 const TAB = '  ';
 
-class BaseQueryBuilder<T extends Record<string, any>> {
+export class BaseQueryBuilder<T extends Record<string, any>> {
   private conditions: Array<{ expression: string; path: string; value?: any }> = [];
   protected nestedBuilders: Array<ConjunctionQueryBuilder<T> | DisjunctionQueryBuilder<T>> = [];
   protected connectionType: 'conjunction' | 'disjunction' = 'conjunction';
@@ -191,7 +191,7 @@ class BaseQueryBuilder<T extends Record<string, any>> {
   }
 }
 
-class ConjunctionQueryBuilder<T extends Record<string, any>> extends BaseQueryBuilder<T> {
+export class ConjunctionQueryBuilder<T extends Record<string, any>> extends BaseQueryBuilder<T> {
   constructor() {
     super();
     this.connectionType = 'conjunction';
@@ -206,7 +206,7 @@ class ConjunctionQueryBuilder<T extends Record<string, any>> extends BaseQueryBu
   }
 }
 
-class DisjunctionQueryBuilder<T extends Record<string, any>> extends BaseQueryBuilder<T> {
+export class DisjunctionQueryBuilder<T extends Record<string, any>> extends BaseQueryBuilder<T> {
   constructor() {
     super();
     this.connectionType = 'disjunction';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,4 @@
+export type { BaseQueryBuilder, ConjunctionQueryBuilder, DisjunctionQueryBuilder } from './CosmosQueryBuilder';
+export type { ArrayElement, Path, PathValue, PickPath, UnionToIntersection } from './typeHelpers';
+
 export { CosmosQueryBuilder } from './CosmosQueryBuilder';


### PR DESCRIPTION
The query builder is really useful and we use it for our projects.
We ran into the issue that the queries sometimes become so complex that we want to split them up in different files so we can re-use some of the logic that goes into building these queries.
For that we need to be able to reference the types that are used internally, so the arguments can be satisfied when using `or()` and `and()`.

This change exports the query builder and utility types, so they can be used by projects depending on cosmonaut.