### PR TITLE
Fix to ignore empty nested builders, support for partial matches in arrayContains

### DIFF
--- a/src/CosmosQueryBuilder.spec.ts
+++ b/src/CosmosQueryBuilder.spec.ts
@@ -65,4 +65,23 @@ GROUP BY c.mode, c.softDeleted.by",
       .query(container)
       .fetchAll();
   });
+
+  it('should ignore empty OR\'s and AND\'s', () => {
+    const { querySpec } = new CosmosQueryBuilder<Machine>()
+      .select('id')
+      .greater('price', 50)
+      .or((d) => d.and(a => a.or(o => o)))
+      .take(10)
+      .build({ pretty: true, noParams: true });
+
+    expect(querySpec).toMatchInlineSnapshot(`
+{
+  "parameters": [],
+  "query": "SELECT c.id
+FROM c
+WHERE c.price > 50
+OFFSET 0 LIMIT 10",
+}
+`);
+  });
 });

--- a/src/CosmosQueryBuilder.ts
+++ b/src/CosmosQueryBuilder.ts
@@ -9,6 +9,10 @@ export class BaseQueryBuilder<T extends Record<string, any>> {
   protected nestedBuilders: Array<ConjunctionQueryBuilder<T> | DisjunctionQueryBuilder<T>> = [];
   protected connectionType: 'conjunction' | 'disjunction' = 'conjunction';
 
+  public get numConditions(): number {
+    return this.conditions.length + this.nestedBuilders.reduce((a, b) => a + b.numConditions, 0);
+  }
+
   constructor() {
     this.equals = this.equals.bind(this);
     this.notEquals = this.notEquals.bind(this);
@@ -139,9 +143,10 @@ export class BaseQueryBuilder<T extends Record<string, any>> {
 
   arrayContains<P extends Exclude<Path<T>, NonNullable<V> extends any[] ? never : P>, V extends PathValue<T, P>>(
     path: P,
-    value: ArrayElement<V>
+    value: ArrayElement<V>,
+    partialMatch = false
   ) {
-    this.addCondition(`ARRAY_CONTAINS($path, $value)`, path, value);
+    this.addCondition(`ARRAY_CONTAINS($path, $value, ${String(partialMatch)})`, path, value);
     return this;
   }
 
@@ -169,11 +174,13 @@ export class BaseQueryBuilder<T extends Record<string, any>> {
           );
       }),
       ...this.nestedBuilders.map((nestedBuilder) => {
+        if(nestedBuilder.numConditions === 0) return undefined;
+
         const { conditionsExpression: nestedConditionsExpression } = (
           nestedBuilder as BaseQueryBuilder<T>
         ).getConditionsExpression(noParams, parameters, indention + 1);
         return `(\n${TAB.repeat(indention + 1)}${nestedConditionsExpression}\n${TAB.repeat(indention)})`;
-      }),
+      }).filter(Boolean),
     ].join(`\n${TAB.repeat(indention)}${this.connectionType === 'conjunction' ? 'AND' : 'OR'} `);
 
     return { conditionsExpression, parameters };


### PR DESCRIPTION
Sometimes you loop over an array of conditions and it adds complexity to know if any conditions will be required.
For example:
```typescript
const qb = new new CosmosQueryBuilder<Machine>();
const filters: {x: number, y: number}[] = [];

qb.or(d => filters.forEach(filter => {
  if(filter.x > 1) d.equals('x', x);
  if(filter.y > 2) d.equals('y', y);
}));
```

In this scenario it would simplify the code by not having to check beforehand if a OR is even necessary.
This fix just ignores empty OR's and AND's from the WHERE clause altogether.

It also adds support for partial matches in the `arrayContains` method (see [documentation](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/array-contains)).